### PR TITLE
Zeppelin 3092 remote GitHub integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ spark-1.*-bin-hadoop*
 
 lens/lens-cli-hist.log
 
+# Zeppelin server
+zeppelin-server/local-repo
 
 # conf file
 conf/zeppelin-env.sh

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -480,4 +480,31 @@
   <value>10000:10010</value>
 </property>
 -->
+
+<!-- GitHub configurations
+<property>
+  <name>zeppelin.notebook.git.remote.url</name>
+  <value>git@github.com:mohamagdy/zeppelin-notebooks.git</value>
+  <description>remote Git repository URL</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.username</name>
+  <value>token</value>
+  <description>remote Git repository username</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.access-token</name>
+  <value>1b29e853bc73b90af0d280233101f91b9105d7cb</value>
+  <description>remote Git repository password</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.remote</name>
+  <value>origin</value>
+  <description>Git repository remote</description>
+</property>
+-->
+
 </configuration>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -329,6 +329,30 @@ If both are defined, then the **environment variables** will take priority.
     <td>false</td>
     <td>Enable directory listings on server.</td>
   </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.git.remote.url</h6></td>
+    <td></td>
+    <td>GitHub's repository URL. It could be either the HTTP URL or the SSH URL. For example git@github.com:apache/zeppelin.git</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.git.remote.username</h6></td>
+    <td>token</td>
+    <td>GitHub username. By default it is `token` to use GitHub's API</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.git.remote.access-token</h6></td>
+    <td>token</td>
+    <td>GitHub access token to use GitHub's API. If username/password combination is used and not GitHub API, then this value is the password</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.git.remote.origin</h6></td>
+    <td>token</td>
+    <td>GitHub remote name. Default is `origin`</td>
+  </tr>
 </table>
 
 
@@ -431,7 +455,7 @@ The following properties needs to be updated in the `zeppelin-site.xml` in order
 
 ### Storing user credentials
 
-In order to avoid having to re-enter credentials every time you restart/redeploy Zeppelin, you can store the user credentials. Zeppelin supports this via the ZEPPELIN_CREDENTIALS_PERSIST configuration.
+In order to avoid having to re-enter credentials every?time you restart/redeploy Zeppelin, you can store the user credentials. Zeppelin supports this via the ZEPPELIN_CREDENTIALS_PERSIST configuration.
 
 Please notice that passwords will be stored in *plain text* by default. To encrypt the passwords, use the ZEPPELIN_CREDENTIALS_ENCRYPT_KEY config variable. This will encrypt passwords using the AES-128 algorithm.
 
@@ -473,5 +497,9 @@ update your configuration with the obfuscated password :
 </property>
 ```
 
+### Create GitHub Access Token
+
+When using GitHub to track notebooks, one can use GitHub's API for authentication. To create an access token, please use the following link https://github.com/settings/tokens.
+The value of the access token generated is set in the `zeppelin.notebook.git.remote.access-token` property.
 
 **Note:** After updating these configurations, Zeppelin server needs to be restarted.

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -455,7 +455,7 @@ The following properties needs to be updated in the `zeppelin-site.xml` in order
 
 ### Storing user credentials
 
-In order to avoid having to re-enter credentials every?time you restart/redeploy Zeppelin, you can store the user credentials. Zeppelin supports this via the ZEPPELIN_CREDENTIALS_PERSIST configuration.
+In order to avoid having to re-enter credentials every time you restart/redeploy Zeppelin, you can store the user credentials. Zeppelin supports this via the ZEPPELIN_CREDENTIALS_PERSIST configuration.
 
 Please notice that passwords will be stored in *plain text* by default. To encrypt the passwords, use the ZEPPELIN_CREDENTIALS_ENCRYPT_KEY config variable. This will encrypt passwords using the AES-128 algorithm.
 

--- a/docs/setup/storage/storage.md
+++ b/docs/setup/storage/storage.md
@@ -393,4 +393,13 @@ To enable GitHub tracking, uncomment the following properties in `zeppelin-site.
 </property>
 ```
 
+And set the `zeppelin.notebook.storage` propery to `org.apache.zeppelin.notebook.repo.GitHubNotebookRepo`
+
+```sh
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.GitHubNotebookRepo</value>
+</property>
+```
+
 The access token could be obtained by following the steps on this link https://github.com/settings/tokens.

--- a/docs/setup/storage/storage.md
+++ b/docs/setup/storage/storage.md
@@ -34,6 +34,7 @@ There are few notebook storage systems available for a use out of the box:
   * storage using Amazon S3 service - `S3NotebookRepo`
   * storage using Azure service - `AzureNotebookRepo`
   * storage using MongoDB - `MongoNotebookRepo`
+  * storage using GitHub - `GitHubNotebookRepo`
 
 Multiple storage systems can be used at the same time by providing a comma-separated list of the class-names in the configuration.
 By default, only first two of them will be automatically kept in sync by Zeppelin.
@@ -361,3 +362,35 @@ export ZEPPELIN_NOTEBOOK_MONGO_AUTOIMPORT=true
 
 #### Import your local notes automatically
 By setting `ZEPPELIN_NOTEBOOK_MONGO_AUTOIMPORT` as `true` (default `false`), you can import your local notes automatically when Zeppelin daemon starts up. This feature is for easy migration from local file system storage to MongoDB storage. A note with ID already existing in the collection will not be imported.
+
+## Notebook Storage in GitHub
+
+To enable GitHub tracking, uncomment the following properties in `zeppelin-site.xml`
+
+```sh
+<property>
+  <name>zeppelin.notebook.git.remote.url</name>
+  <value>git@github.com:mohamagdy/zeppelin-notebooks.git</value>
+  <description>remote Git repository URL</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.username</name>
+  <value>token</value>
+  <description>remote Git repository username</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.access-token</name>
+  <value>1b29e853bc73b90af0d280233101f91b9105d7cb</value>
+  <description>remote Git repository password</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.remote</name>
+  <value>origin</value>
+  <description>Git repository remote</description>
+</property>
+```
+
+The access token could be obtained by following the steps on this link https://github.com/settings/tokens.

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -558,6 +558,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN);
   }
 
+  public String getZeppelinNotebookGitRemoteOrigin() {
+    return getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN);
+  }
+
   public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
                                                 ConfigurationKeyPredicate predicate) {
     Map<String, String> configurations = new HashMap<>();
@@ -739,7 +743,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL("zeppelin.notebook.git.remote.url", ""),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME("zeppelin.notebook.git.remote.username", "token"),
-    ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN("zeppelin.notebook.git.remote.access-token", "");
+    ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN("zeppelin.notebook.git.remote.access-token", ""),
+    ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN("zeppelin.notebook.git.remote.origin", "origin");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -546,6 +546,12 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_CLASS);
   }
 
+  public String getZeppelinNotebookGitURL() { return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL); }
+  public String getZeppelinNotebookGitUsername() { return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME); }
+  public String getZeppelinNotebookGitAccessToken() {
+    return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN);
+  }
+
   public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
                                                 ConfigurationKeyPredicate predicate) {
     Map<String, String> configurations = new HashMap<>();
@@ -723,8 +729,11 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_THRESHOLD(
         "zeppelin.interpreter.lifecyclemanager.timeout.threshold", 3600000L),
 
-    ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", "");
+    ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", ""),
 
+    ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL("zeppelin.notebook.git.remote.url", ""),
+    ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME("zeppelin.notebook.git.remote.username", "token"),
+    ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN("zeppelin.notebook.git.remote.access-token", "");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -546,8 +546,14 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_CLASS);
   }
 
-  public String getZeppelinNotebookGitURL() { return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL); }
-  public String getZeppelinNotebookGitUsername() { return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME); }
+  public String getZeppelinNotebookGitURL() {
+    return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL);
+  }
+
+  public String getZeppelinNotebookGitUsername() {
+    return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME);
+  }
+
   public String getZeppelinNotebookGitAccessToken() {
     return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN);
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -209,6 +209,18 @@ public class ZeppelinServer extends Application {
       }
     });
 
+    
+    // when zeppelin is started inside of ide (especially for eclipse)
+    // for graceful shutdown, input any key in console window
+    if (System.getenv("ZEPPELIN_IDENT_STRING") == null) {
+      try {
+        System.in.read();
+      } catch (IOException e) {
+        LOG.error("Exception in ZeppelinServer while main ", e);
+      }
+      System.exit(0);
+    }
+
     jettyWebServer.join();
     ZeppelinServer.notebook.getInterpreterSettingManager().close();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -209,7 +209,7 @@ public class ZeppelinServer extends Application {
       }
     });
 
-    
+
     // when zeppelin is started inside of ide (especially for eclipse)
     // for graceful shutdown, input any key in console window
     if (System.getenv("ZEPPELIN_IDENT_STRING") == null) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -209,18 +209,6 @@ public class ZeppelinServer extends Application {
       }
     });
 
-
-    // when zeppelin is started inside of ide (especially for eclipse)
-    // for graceful shutdown, input any key in console window
-    if (System.getenv("ZEPPELIN_IDENT_STRING") == null) {
-      try {
-        System.in.read();
-      } catch (IOException e) {
-        LOG.error("Exception in ZeppelinServer while main ", e);
-      }
-      System.exit(0);
-    }
-
     jettyWebServer.join();
     ZeppelinServer.notebook.getInterpreterSettingManager().close();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -823,9 +823,9 @@ public class NotebookServer extends WebSocketServlet
 
     String user = fromMessage.principal;
 
-    Note note = notebook.getNote(noteId);
-    if (note != null) {
+    Note note = notebook.getNoteAfterReloadFromRepo(noteId);
 
+    if (note != null) {
       if (!hasParagraphReaderPermission(conn, notebook, noteId,
           userAndRoles, fromMessage.principal, "read")) {
         return;

--- a/zeppelin-server/src/main/resources/zeppelin-site.xml
+++ b/zeppelin-server/src/main/resources/zeppelin-site.xml
@@ -247,7 +247,7 @@
 
 <property>
   <name>zeppelin.notebook.storage</name>
-  <value>org.apache.zeppelin.notebook.repo.GitNotebookRepo</value>
+  <value>org.apache.zeppelin.notebook.repo.GitHubNotebookRepo</value>
   <description>versioned notebook persistence layer implementation</description>
 </property>
 
@@ -267,6 +267,12 @@
   <name>zeppelin.notebook.git.remote.access-token</name>
   <value>1b29e853bc73b90af0d280233101f91b9105d7cb</value>
   <description>remote Git repository password</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.origin</name>
+  <value>origin</value>
+  <description>Git repository remote</description>
 </property>
 
 <property>

--- a/zeppelin-server/src/main/resources/zeppelin-site.xml
+++ b/zeppelin-server/src/main/resources/zeppelin-site.xml
@@ -1,0 +1,501 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+
+<property>
+  <name>zeppelin.server.addr</name>
+  <value>0.0.0.0</value>
+  <description>Server address</description>
+</property>
+
+<property>
+  <name>zeppelin.server.port</name>
+  <value>8080</value>
+  <description>Server port.</description>
+</property>
+
+<property>
+  <name>zeppelin.server.ssl.port</name>
+  <value>8443</value>
+  <description>Server ssl port. (used when ssl property is set to true)</description>
+</property>
+
+<property>
+  <name>zeppelin.server.context.path</name>
+  <value>/</value>
+  <description>Context Path of the Web Application</description>
+</property>
+
+<property>
+  <name>zeppelin.war.tempdir</name>
+  <value>webapps</value>
+  <description>Location of jetty temporary directory</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.dir</name>
+  <value>notebook</value>
+  <description>path or URI for notebook persist</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.homescreen</name>
+  <value></value>
+  <description>id of notebook to be displayed in homescreen. ex) 2A94M5J1Z Empty value displays default home screen</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.homescreen.hide</name>
+  <value>false</value>
+  <description>hide homescreen notebook from list when this value set to true</description>
+</property>
+
+
+<!-- Amazon S3 notebook storage -->
+<!-- Creates the following directory structure: s3://{bucket}/{username}/{notebook-id}/note.json -->
+<!--
+<property>
+  <name>zeppelin.notebook.s3.user</name>
+  <value>user</value>
+  <description>user name for s3 folder structure</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.s3.bucket</name>
+  <value>zeppelin</value>
+  <description>bucket name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.s3.endpoint</name>
+  <value>s3.amazonaws.com</value>
+  <description>endpoint for s3 bucket</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.S3NotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+-->
+
+<!-- Additionally, encryption is supported for notebook data stored in S3 -->
+<!-- Use the AWS KMS to encrypt data -->
+<!-- If used, the EC2 role assigned to the EMR cluster must have rights to use the given key -->
+<!-- See https://aws.amazon.com/kms/ and http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html -->
+<!--
+<property>
+  <name>zeppelin.notebook.s3.kmsKeyID</name>
+  <value>AWS-KMS-Key-UUID</value>
+  <description>AWS KMS key ID used to encrypt notebook data in S3</description>
+</property>
+-->
+
+<!-- provide region of your KMS key -->
+<!-- See http://docs.aws.amazon.com/general/latest/gr/rande.html#kms_region for region codes names -->
+<!--
+<property>
+  <name>zeppelin.notebook.s3.kmsKeyRegion</name>
+  <value>us-east-1</value>
+  <description>AWS KMS key region in your AWS account</description>
+</property>
+-->
+
+<!-- Use a custom encryption materials provider to encrypt data -->
+<!-- No configuration is given to the provider, so you must use system properties or another means to configure -->
+<!-- See https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/EncryptionMaterialsProvider.html -->
+<!--
+<property>
+  <name>zeppelin.notebook.s3.encryptionMaterialsProvider</name>
+  <value>provider implementation class name</value>
+  <description>Custom encryption materials provider used to encrypt notebook data in S3</description>
+</property>
+-->
+
+<!-- Server-side encryption enabled for notebooks -->
+<!--
+<property>
+  <name>zeppelin.notebook.s3.sse</name>
+  <value>true</value>
+  <description>Server-side encryption enabled for notebooks</description>
+</property>
+-->
+
+<!-- Optional override to control which signature algorithm should be used to sign AWS requests -->
+<!-- Set this property to "S3SignerType" if your AWS S3 compatible APIs support only AWS Signature Version 2 such as Ceph. -->
+<!--
+<property>
+  <name>zeppelin.notebook.s3.signerOverride</name>
+  <value>S3SignerType</value>
+  <description>optional override to control which signature algorithm should be used to sign AWS requests</description>
+</property>
+-->
+
+<!-- If using Azure for storage use the following settings -->
+<!--
+<property>
+  <name>zeppelin.notebook.azure.connectionString</name>
+  <value>DefaultEndpointsProtocol=https;AccountName=<accountName>;AccountKey=<accountKey></value>
+  <description>Azure account credentials</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.azure.share</name>
+  <value>zeppelin</value>
+  <description>share name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.azure.user</name>
+  <value>user</value>
+  <description>optional user name for Azure folder structure</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.AzureNotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+-->
+
+<!-- Notebook storage layer using local file system
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</value>
+  <description>local notebook persistence layer implementation</description>
+</property>
+-->
+
+<!-- Notebook storage layer using hadoop compatible file system
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.FileSystemNotebookRepo</value>
+  <description>Hadoop compatible file system notebook persistence layer implementation, such as local file system, hdfs, azure wasb, s3 and etc.</description>
+</property>
+
+<property>
+  <name>zeppelin.server.kerberos.keytab</name>
+  <value></value>
+  <description>keytab for accessing kerberized hdfs</description>
+</property>
+
+<property>
+  <name>zeppelin.server.kerberos.principal</name>
+  <value></value>
+  <description>principal for accessing kerberized hdfs</description>
+</property>
+-->
+
+<!-- For connecting your Zeppelin with ZeppelinHub -->
+<!--
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.GitNotebookRepo, org.apache.zeppelin.notebook.repo.zeppelinhub.ZeppelinHubRepo</value>
+  <description>two notebook persistence layers (versioned local + ZeppelinHub)</description>
+</property>
+-->
+
+<!-- MongoDB notebook storage -->
+<!--
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.MongoNotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.mongo.uri</name>
+  <value>mongodb://localhost</value>
+  <description>MongoDB connection URI used to connect to a MongoDB database server</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.mongo.database</name>
+  <value>zeppelin</value>
+  <description>database name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.mongo.collection</name>
+  <value>notes</value>
+  <description>collection name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.mongo.autoimport</name>
+  <value>false</value>
+  <description>import local notes into MongoDB automatically on startup</description>
+</property>
+-->
+
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.GitNotebookRepo</value>
+  <description>versioned notebook persistence layer implementation</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.url</name>
+  <value>git@github.com:mohamagdy/zeppelin-notebooks.git</value>
+  <description>remote Git repository URL</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.username</name>
+  <value>token</value>
+  <description>remote Git repository username</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.git.remote.access-token</name>
+  <value>1b29e853bc73b90af0d280233101f91b9105d7cb</value>
+  <description>remote Git repository password</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.one.way.sync</name>
+  <value>false</value>
+  <description>If there are multiple notebook storages, should we treat the first one as the only source of truth?</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.dir</name>
+  <value>interpreter</value>
+  <description>Interpreter implementation base directory</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.localRepo</name>
+  <value>local-repo</value>
+  <description>Local repository for interpreter's additional dependency loading</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.dep.mvnRepo</name>
+  <value>http://repo1.maven.org/maven2/</value>
+  <description>Remote principal repository for interpreter's additional dependency loading</description>
+</property>
+
+<property>
+  <name>zeppelin.dep.localrepo</name>
+  <value>local-repo</value>
+  <description>Local repository for dependency loader</description>
+</property>
+
+<property>
+  <name>zeppelin.helium.node.installer.url</name>
+  <value>https://nodejs.org/dist/</value>
+  <description>Remote Node installer url for Helium dependency loader</description>
+</property>
+
+<property>
+  <name>zeppelin.helium.npm.installer.url</name>
+  <value>http://registry.npmjs.org/</value>
+  <description>Remote Npm installer url for Helium dependency loader</description>
+</property>
+
+<property>
+  <name>zeppelin.helium.yarnpkg.installer.url</name>
+  <value>https://github.com/yarnpkg/yarn/releases/download/</value>
+  <description>Remote Yarn package installer url for Helium dependency loader</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreters</name>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.rinterpreter.RRepl,org.apache.zeppelin.rinterpreter.KnitR,org.apache.zeppelin.spark.SparkRInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.file.HDFSFileInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,,org.apache.zeppelin.python.PythonInterpreter,org.apache.zeppelin.python.PythonInterpreterPandasSql,org.apache.zeppelin.python.PythonCondaInterpreter,org.apache.zeppelin.python.PythonDockerInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.jdbc.JDBCInterpreter,org.apache.zeppelin.kylin.KylinInterpreter,org.apache.zeppelin.elasticsearch.ElasticsearchInterpreter,org.apache.zeppelin.scalding.ScaldingInterpreter,org.apache.zeppelin.alluxio.AlluxioInterpreter,org.apache.zeppelin.hbase.HbaseInterpreter,org.apache.zeppelin.livy.LivySparkInterpreter,org.apache.zeppelin.livy.LivyPySparkInterpreter,org.apache.zeppelin.livy.LivyPySpark3Interpreter,org.apache.zeppelin.livy.LivySparkRInterpreter,org.apache.zeppelin.livy.LivySparkSQLInterpreter,org.apache.zeppelin.bigquery.BigQueryInterpreter,org.apache.zeppelin.beam.BeamInterpreter,org.apache.zeppelin.pig.PigInterpreter,org.apache.zeppelin.pig.PigQueryInterpreter,org.apache.zeppelin.scio.ScioInterpreter,org.apache.zeppelin.groovy.GroovyInterpreter</value>
+  <description>Comma separated interpreter configurations. First interpreter become a default</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.group.order</name>
+  <value>spark,md,angular,sh,livy,alluxio,file,psql,flink,python,ignite,lens,cassandra,geode,kylin,elasticsearch,scalding,jdbc,hbase,bigquery,beam,groovy</value>
+  <description></description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.connect.timeout</name>
+  <value>990000</value>
+  <description>Interpreter process connect timeout in msec.</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.output.limit</name>
+  <value>102400</value>
+  <description>Output message from interpreter exceeding the limit will be truncated</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl</name>
+  <value>false</value>
+  <description>Should SSL be used by the servers?</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.client.auth</name>
+  <value>false</value>
+  <description>Should client authentication be used for SSL connections?</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.keystore.path</name>
+  <value>keystore</value>
+  <description>Path to keystore relative to Zeppelin configuration directory</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.keystore.type</name>
+  <value>JKS</value>
+  <description>The format of the given keystore (e.g. JKS or PKCS12)</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.keystore.password</name>
+  <value>change me</value>
+  <description>Keystore password. Can be obfuscated by the Jetty Password tool</description>
+</property>
+
+<!--
+<property>
+  <name>zeppelin.ssl.key.manager.password</name>
+  <value>change me</value>
+  <description>Key Manager password. Defaults to keystore password. Can be obfuscated.</description>
+</property>
+-->
+
+<property>
+  <name>zeppelin.ssl.truststore.path</name>
+  <value>truststore</value>
+  <description>Path to truststore relative to Zeppelin configuration directory. Defaults to the keystore path</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.truststore.type</name>
+  <value>JKS</value>
+  <description>The format of the given truststore (e.g. JKS or PKCS12). Defaults to the same type as the keystore type</description>
+</property>
+
+<!--
+<property>
+  <name>zeppelin.ssl.truststore.password</name>
+  <value>change me</value>
+  <description>Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to the keystore password</description>
+</property>
+-->
+
+<property>
+  <name>zeppelin.server.allowed.origins</name>
+  <value>*</value>
+  <description>Allowed sources for REST and WebSocket requests (i.e. http://onehost:8080,http://otherhost.com). If you leave * you are vulnerable to https://issues.apache.org/jira/browse/ZEPPELIN-173</description>
+</property>
+
+<property>
+  <name>zeppelin.anonymous.allowed</name>
+  <value>true</value>
+  <description>Anonymous user allowed by default</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.default.owner.username</name>
+  <value></value>
+  <description>Set owner role by default</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.public</name>
+  <value>true</value>
+  <description>Make notebook public by default when created, private otherwise</description>
+</property>
+
+<property>
+  <name>zeppelin.websocket.max.text.message.size</name>
+  <value>1024000</value>
+  <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>
+</property>
+
+<property>
+  <name>zeppelin.server.default.dir.allowed</name>
+  <value>false</value>
+  <description>Enable directory listings on server.</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.lifecyclemanager.class</name>
+  <value>org.apache.zeppelin.interpreter.lifecycle.TimeoutLifecycleManager</value>
+  <description>LifecycleManager class for managing the lifecycle of interpreters, by default interpreter will
+  be closed after timeout</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.lifecyclemanager.timeout.checkinterval</name>
+  <value>60000</value>
+  <description>milliseconds of the interval to checking whether interpreter is time out</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.lifecyclemanager.timeout.threshold</name>
+  <value>3600000</value>
+  <description>milliseconds of the interpreter timeout threshold, by default it is 1 hour</description>
+</property>
+
+<!--
+<property>
+    <name>zeppelin.server.jetty.name</name>
+    <value>Jetty(7.6.0.v20120127)</value>
+    <description>Hardcoding Application Server name to Prevent Fingerprinting</description>
+</property>
+-->
+
+<!--
+<property>
+    <name>zeppelin.server.jetty.request.header.size</name>
+    <value>8192</value>
+    <description>Http Request Header Size Limit (to prevent HTTP 413)</description>
+</property>
+-->
+
+<!--
+<property>
+  <name>zeppelin.server.xframe.options</name>
+  <value>SAMEORIGIN</value>
+  <description>The X-Frame-Options HTTP response header can be used to indicate whether or not a browser should be allowed to render a page in a frame/iframe/object.</description>
+</property>
+-->
+
+<!--
+<property>
+  <name>zeppelin.server.strict.transport</name>
+  <value>max-age=631138519</value>
+  <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS. Value is in Seconds, the default value is equivalent to 20 years.</description>
+</property>
+-->
+<!--
+<property>
+  <name>zeppelin.server.xxss.protection</name>
+  <value>1</value>
+  <description>The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. When value is set to 1 and a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).</description>
+</property>
+-->
+<!--
+<property>
+  <name>zeppelin.interpreter.callback.portRange</name>
+  <value>10000:10010</value>
+</property>
+-->
+</configuration>

--- a/zeppelin-server/src/test/resources/2A94M5J1Z/note.json
+++ b/zeppelin-server/src/test/resources/2A94M5J1Z/note.json
@@ -1,0 +1,376 @@
+{
+  "paragraphs": [
+    {
+      "text": "%md\n## Welcome to Zeppelin.\n##### This is a live tutorial, you can run the code yourself. (Shift-Enter to Run)",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:32:15 PM",
+      "config": {
+        "colWidth": 12.0,
+        "editorHide": true,
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false,
+              "keys": [],
+              "values": [],
+              "groups": [],
+              "scatter": {}
+            }
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true
+        },
+        "editorMode": "ace/mode/markdown",
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003ch2\u003eWelcome to Zeppelin.\u003c/h2\u003e\n\u003ch5\u003eThis is a live tutorial, you can run the code yourself. (Shift-Enter to Run)\u003c/h5\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423836981412_-1007008116",
+      "id": "20150213-231621_168813393",
+      "dateCreated": "Feb 13, 2015 11:16:21 PM",
+      "dateStarted": "Dec 17, 2016 3:32:15 PM",
+      "dateFinished": "Dec 17, 2016 3:32:18 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "title": "Load data into table",
+      "text": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\n\n// Zeppelin creates and injects sc (SparkContext) and sqlContext (HiveContext or SqlContext)\n// So you don\u0027t need create them manually\n\n// load bank data\nval bankText \u003d sc.parallelize(\n    IOUtils.toString(\n        new URL(\"https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv\"),\n        Charset.forName(\"utf8\")).split(\"\\n\"))\n\ncase class Bank(age: Integer, job: String, marital: String, education: String, balance: Integer)\n\nval bank \u003d bankText.map(s \u003d\u003e s.split(\";\")).filter(s \u003d\u003e s(0) !\u003d \"\\\"age\\\"\").map(\n    s \u003d\u003e Bank(s(0).toInt, \n            s(1).replaceAll(\"\\\"\", \"\"),\n            s(2).replaceAll(\"\\\"\", \"\"),\n            s(3).replaceAll(\"\\\"\", \"\"),\n            s(5).replaceAll(\"\\\"\", \"\").toInt\n        )\n).toDF()\nbank.registerTempTable(\"bank\")",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:30:09 PM",
+      "config": {
+        "colWidth": 12.0,
+        "title": true,
+        "enabled": true,
+        "editorMode": "ace/mode/scala",
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false
+            }
+          }
+        ],
+        "editorSetting": {
+          "language": "scala",
+          "editOnDblClick": false
+        }
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TEXT",
+            "data": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[36] at parallelize at \u003cconsole\u003e:43\ndefined class Bank\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string ... 3 more fields]\nwarning: there were 1 deprecation warning(s); re-run with -deprecation for details\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423500779206_-1502780787",
+      "id": "20150210-015259_1403135953",
+      "dateCreated": "Feb 10, 2015 1:52:59 AM",
+      "dateStarted": "Dec 17, 2016 3:30:09 PM",
+      "dateFinished": "Dec 17, 2016 3:30:58 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%sql \nselect age, count(1) value\nfrom bank \nwhere age \u003c 30 \ngroup by age \norder by age",
+      "user": "anonymous",
+      "dateUpdated": "Mar 17, 2017 12:18:02 PM",
+      "config": {
+        "colWidth": 4.0,
+        "results": [
+          {
+            "graph": {
+              "mode": "multiBarChart",
+              "height": 366.0,
+              "optionOpen": false
+            },
+            "helium": {}
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "sql",
+          "editOnDblClick": false
+        },
+        "editorMode": "ace/mode/sql"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423500782552_-1439281894",
+      "id": "20150210-015302_1492795503",
+      "dateCreated": "Feb 10, 2015 1:53:02 AM",
+      "dateStarted": "Dec 17, 2016 3:30:13 PM",
+      "dateFinished": "Dec 17, 2016 3:31:04 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%sql \nselect age, count(1) value \nfrom bank \nwhere age \u003c ${maxAge\u003d30} \ngroup by age \norder by age",
+      "user": "anonymous",
+      "dateUpdated": "Mar 17, 2017 12:17:39 PM",
+      "config": {
+        "colWidth": 4.0,
+        "results": [
+          {
+            "graph": {
+              "mode": "multiBarChart",
+              "height": 294.0,
+              "optionOpen": false
+            },
+            "helium": {}
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "sql",
+          "editOnDblClick": false
+        },
+        "editorMode": "ace/mode/sql"
+      },
+      "settings": {
+        "params": {
+          "maxAge": "35"
+        },
+        "forms": {
+          "maxAge": {
+            "name": "maxAge",
+            "defaultValue": "30",
+            "hidden": false
+          }
+        }
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n30\t150\n31\t199\n32\t224\n33\t186\n34\t231\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423720444030_-1424110477",
+      "id": "20150212-145404_867439529",
+      "dateCreated": "Feb 12, 2015 2:54:04 PM",
+      "dateStarted": "Dec 17, 2016 3:30:58 PM",
+      "dateFinished": "Dec 17, 2016 3:31:07 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%sql \nselect age, count(1) value \nfrom bank \nwhere marital\u003d\"${marital\u003dsingle,single|divorced|married}\" \ngroup by age \norder by age",
+      "user": "anonymous",
+      "dateUpdated": "Mar 17, 2017 12:18:18 PM",
+      "config": {
+        "colWidth": 4.0,
+        "results": [
+          {
+            "graph": {
+              "mode": "stackedAreaChart",
+              "height": 280.0,
+              "optionOpen": false
+            },
+            "helium": {}
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "sql",
+          "editOnDblClick": false
+        },
+        "editorMode": "ace/mode/sql"
+      },
+      "settings": {
+        "params": {
+          "marital": "single"
+        },
+        "forms": {
+          "marital": {
+            "name": "marital",
+            "defaultValue": "single",
+            "options": [
+              {
+                "value": "single"
+              },
+              {
+                "value": "divorced"
+              },
+              {
+                "value": "married"
+              }
+            ],
+            "hidden": false
+          }
+        }
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t17\n24\t13\n25\t33\n26\t56\n27\t64\n28\t78\n29\t56\n30\t92\n31\t86\n32\t105\n33\t61\n34\t75\n35\t46\n36\t50\n37\t43\n38\t44\n39\t30\n40\t25\n41\t19\n42\t23\n43\t21\n44\t20\n45\t15\n46\t14\n47\t12\n48\t12\n49\t11\n50\t8\n51\t6\n52\t9\n53\t4\n55\t3\n56\t3\n57\t2\n58\t7\n59\t2\n60\t5\n66\t2\n69\t1\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423836262027_-210588283",
+      "id": "20150213-230422_1600658137",
+      "dateCreated": "Feb 13, 2015 11:04:22 PM",
+      "dateStarted": "Dec 17, 2016 3:31:05 PM",
+      "dateFinished": "Dec 17, 2016 3:31:09 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\n## Congratulations, it\u0027s done.\n##### You can create your own notebook in \u0027Notebook\u0027 menu. Good luck!",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:30:24 PM",
+      "config": {
+        "colWidth": 12.0,
+        "editorHide": true,
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false
+            }
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true
+        },
+        "editorMode": "ace/mode/markdown",
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003ch2\u003eCongratulations, it\u0026rsquo;s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0026lsquo;Notebook\u0026rsquo; menu. Good luck!\u003c/h5\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423836268492_216498320",
+      "id": "20150213-230428_1231780373",
+      "dateCreated": "Feb 13, 2015 11:04:28 PM",
+      "dateStarted": "Dec 17, 2016 3:30:24 PM",
+      "dateFinished": "Dec 17, 2016 3:30:29 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\n\nAbout bank data\n\n```\nCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n```",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:30:34 PM",
+      "config": {
+        "colWidth": 12.0,
+        "editorHide": true,
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false
+            }
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true
+        },
+        "editorMode": "ace/mode/markdown",
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u0026#39;2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1427420818407_872443482",
+      "id": "20150326-214658_12335843",
+      "dateCreated": "Mar 26, 2015 9:46:58 PM",
+      "dateStarted": "Dec 17, 2016 3:30:34 PM",
+      "dateFinished": "Dec 17, 2016 3:30:34 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "config": {},
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "apps": [],
+      "jobName": "paragraph_1435955447812_-158639899",
+      "id": "20150703-133047_853701097",
+      "dateCreated": "Jul 3, 2015 1:30:47 PM",
+      "status": "READY",
+      "progressUpdateIntervalMs": 500
+    }
+  ],
+  "name": "Zeppelin Tutorial/Basic Features (Spark)",
+  "id": "2A94M5J1Z",
+  "angularObjects": {
+    "2C73DY9P9:shared_process": []
+  },
+  "config": {
+    "looknfeel": "default"
+  },
+  "info": {}
+}

--- a/zeppelin-server/src/test/resources/2A94M5J2Z/note.json
+++ b/zeppelin-server/src/test/resources/2A94M5J2Z/note.json
@@ -1,0 +1,376 @@
+{
+  "paragraphs": [
+    {
+      "text": "%md\n## Welcome to Zeppelin.\n##### This is a live tutorial, you can run the code yourself. (Shift-Enter to Run)",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:32:15 PM",
+      "config": {
+        "colWidth": 12.0,
+        "editorHide": true,
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false,
+              "keys": [],
+              "values": [],
+              "groups": [],
+              "scatter": {}
+            }
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true
+        },
+        "editorMode": "ace/mode/markdown",
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003ch2\u003eWelcome to Zeppelin.\u003c/h2\u003e\n\u003ch5\u003eThis is a live tutorial, you can run the code yourself. (Shift-Enter to Run)\u003c/h5\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423836981412_-1007008116",
+      "id": "20150213-231621_168813393",
+      "dateCreated": "Feb 13, 2015 11:16:21 PM",
+      "dateStarted": "Dec 17, 2016 3:32:15 PM",
+      "dateFinished": "Dec 17, 2016 3:32:18 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "title": "Load data into table",
+      "text": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\n\n// Zeppelin creates and injects sc (SparkContext) and sqlContext (HiveContext or SqlContext)\n// So you don\u0027t need create them manually\n\n// load bank data\nval bankText \u003d sc.parallelize(\n    IOUtils.toString(\n        new URL(\"https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv\"),\n        Charset.forName(\"utf8\")).split(\"\\n\"))\n\ncase class Bank(age: Integer, job: String, marital: String, education: String, balance: Integer)\n\nval bank \u003d bankText.map(s \u003d\u003e s.split(\";\")).filter(s \u003d\u003e s(0) !\u003d \"\\\"age\\\"\").map(\n    s \u003d\u003e Bank(s(0).toInt, \n            s(1).replaceAll(\"\\\"\", \"\"),\n            s(2).replaceAll(\"\\\"\", \"\"),\n            s(3).replaceAll(\"\\\"\", \"\"),\n            s(5).replaceAll(\"\\\"\", \"\").toInt\n        )\n).toDF()\nbank.registerTempTable(\"bank\")",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:30:09 PM",
+      "config": {
+        "colWidth": 12.0,
+        "title": true,
+        "enabled": true,
+        "editorMode": "ace/mode/scala",
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false
+            }
+          }
+        ],
+        "editorSetting": {
+          "language": "scala",
+          "editOnDblClick": false
+        }
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TEXT",
+            "data": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[36] at parallelize at \u003cconsole\u003e:43\ndefined class Bank\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string ... 3 more fields]\nwarning: there were 1 deprecation warning(s); re-run with -deprecation for details\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423500779206_-1502780787",
+      "id": "20150210-015259_1403135953",
+      "dateCreated": "Feb 10, 2015 1:52:59 AM",
+      "dateStarted": "Dec 17, 2016 3:30:09 PM",
+      "dateFinished": "Dec 17, 2016 3:30:58 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%sql \nselect age, count(1) value\nfrom bank \nwhere age \u003c 30 \ngroup by age \norder by age",
+      "user": "anonymous",
+      "dateUpdated": "Mar 17, 2017 12:18:02 PM",
+      "config": {
+        "colWidth": 4.0,
+        "results": [
+          {
+            "graph": {
+              "mode": "multiBarChart",
+              "height": 366.0,
+              "optionOpen": false
+            },
+            "helium": {}
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "sql",
+          "editOnDblClick": false
+        },
+        "editorMode": "ace/mode/sql"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423500782552_-1439281894",
+      "id": "20150210-015302_1492795503",
+      "dateCreated": "Feb 10, 2015 1:53:02 AM",
+      "dateStarted": "Dec 17, 2016 3:30:13 PM",
+      "dateFinished": "Dec 17, 2016 3:31:04 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%sql \nselect age, count(1) value \nfrom bank \nwhere age \u003c ${maxAge\u003d30} \ngroup by age \norder by age",
+      "user": "anonymous",
+      "dateUpdated": "Mar 17, 2017 12:17:39 PM",
+      "config": {
+        "colWidth": 4.0,
+        "results": [
+          {
+            "graph": {
+              "mode": "multiBarChart",
+              "height": 294.0,
+              "optionOpen": false
+            },
+            "helium": {}
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "sql",
+          "editOnDblClick": false
+        },
+        "editorMode": "ace/mode/sql"
+      },
+      "settings": {
+        "params": {
+          "maxAge": "35"
+        },
+        "forms": {
+          "maxAge": {
+            "name": "maxAge",
+            "defaultValue": "30",
+            "hidden": false
+          }
+        }
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n30\t150\n31\t199\n32\t224\n33\t186\n34\t231\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423720444030_-1424110477",
+      "id": "20150212-145404_867439529",
+      "dateCreated": "Feb 12, 2015 2:54:04 PM",
+      "dateStarted": "Dec 17, 2016 3:30:58 PM",
+      "dateFinished": "Dec 17, 2016 3:31:07 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%sql \nselect age, count(1) value \nfrom bank \nwhere marital\u003d\"${marital\u003dsingle,single|divorced|married}\" \ngroup by age \norder by age",
+      "user": "anonymous",
+      "dateUpdated": "Mar 17, 2017 12:18:18 PM",
+      "config": {
+        "colWidth": 4.0,
+        "results": [
+          {
+            "graph": {
+              "mode": "stackedAreaChart",
+              "height": 280.0,
+              "optionOpen": false
+            },
+            "helium": {}
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "sql",
+          "editOnDblClick": false
+        },
+        "editorMode": "ace/mode/sql"
+      },
+      "settings": {
+        "params": {
+          "marital": "single"
+        },
+        "forms": {
+          "marital": {
+            "name": "marital",
+            "defaultValue": "single",
+            "options": [
+              {
+                "value": "single"
+              },
+              {
+                "value": "divorced"
+              },
+              {
+                "value": "married"
+              }
+            ],
+            "hidden": false
+          }
+        }
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t17\n24\t13\n25\t33\n26\t56\n27\t64\n28\t78\n29\t56\n30\t92\n31\t86\n32\t105\n33\t61\n34\t75\n35\t46\n36\t50\n37\t43\n38\t44\n39\t30\n40\t25\n41\t19\n42\t23\n43\t21\n44\t20\n45\t15\n46\t14\n47\t12\n48\t12\n49\t11\n50\t8\n51\t6\n52\t9\n53\t4\n55\t3\n56\t3\n57\t2\n58\t7\n59\t2\n60\t5\n66\t2\n69\t1\n"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423836262027_-210588283",
+      "id": "20150213-230422_1600658137",
+      "dateCreated": "Feb 13, 2015 11:04:22 PM",
+      "dateStarted": "Dec 17, 2016 3:31:05 PM",
+      "dateFinished": "Dec 17, 2016 3:31:09 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\n## Congratulations, it\u0027s done.\n##### You can create your own notebook in \u0027Notebook\u0027 menu. Good luck!",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:30:24 PM",
+      "config": {
+        "colWidth": 12.0,
+        "editorHide": true,
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false
+            }
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true
+        },
+        "editorMode": "ace/mode/markdown",
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003ch2\u003eCongratulations, it\u0026rsquo;s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0026lsquo;Notebook\u0026rsquo; menu. Good luck!\u003c/h5\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1423836268492_216498320",
+      "id": "20150213-230428_1231780373",
+      "dateCreated": "Feb 13, 2015 11:04:28 PM",
+      "dateStarted": "Dec 17, 2016 3:30:24 PM",
+      "dateFinished": "Dec 17, 2016 3:30:29 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\n\nAbout bank data\n\n```\nCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n```",
+      "user": "anonymous",
+      "dateUpdated": "Dec 17, 2016 3:30:34 PM",
+      "config": {
+        "colWidth": 12.0,
+        "editorHide": true,
+        "results": [
+          {
+            "graph": {
+              "mode": "table",
+              "height": 300.0,
+              "optionOpen": false
+            }
+          }
+        ],
+        "enabled": true,
+        "editorSetting": {
+          "language": "markdown",
+          "editOnDblClick": true
+        },
+        "editorMode": "ace/mode/markdown",
+        "tableHide": false
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cdiv class\u003d\"markdown-body\"\u003e\n\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u0026#39;2011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n\u003c/div\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "jobName": "paragraph_1427420818407_872443482",
+      "id": "20150326-214658_12335843",
+      "dateCreated": "Mar 26, 2015 9:46:58 PM",
+      "dateStarted": "Dec 17, 2016 3:30:34 PM",
+      "dateFinished": "Dec 17, 2016 3:30:34 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "config": {},
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "apps": [],
+      "jobName": "paragraph_1435955447812_-158639899",
+      "id": "20150703-133047_853701097",
+      "dateCreated": "Jul 3, 2015 1:30:47 PM",
+      "status": "READY",
+      "progressUpdateIntervalMs": 500
+    }
+  ],
+  "name": "Zeppelin Tutorial/Basic Features (Spark)",
+  "id": "2A94M5J2Z",
+  "angularObjects": {
+    "2C73DY9P9:shared_process": []
+  },
+  "config": {
+    "looknfeel": "default"
+  },
+  "info": {}
+}

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -625,6 +625,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+      <dependency>
+          <groupId>org.eclipse.jgit</groupId>
+          <artifactId>org.eclipse.jgit</artifactId>
+          <version>4.3.1.201605051710-r</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -625,11 +625,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-      <dependency>
-          <groupId>org.eclipse.jgit</groupId>
-          <artifactId>org.eclipse.jgit</artifactId>
-          <version>4.3.1.201605051710-r</version>
-      </dependency>
+    <dependency>
+        <groupId>org.eclipse.jgit</groupId>
+        <artifactId>org.eclipse.jgit</artifactId>
+        <version>4.3.1.201605051710-r</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -297,6 +297,9 @@ public class Notebook implements NoteEventListener {
   }
 
   public Note getNoteAfterReloadFromRepo(String noteId) {
+    // Each time the notebook is requested, it is loaded from the storage repository. This helps in fetching the
+    // latest versions of the notebook if a remote repository is used. For example, if GitHub is integrated, whenever
+    // the notebook is requested, it is pulled from the remote repository.
     loadNoteFromRepo(noteId, new AuthenticationInfo(StringUtils.EMPTY));
     return getNote(noteId);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.quartz.CronScheduleBuilder;
@@ -293,6 +294,11 @@ public class Notebook implements NoteEventListener {
     synchronized (notes) {
       return notes.get(id);
     }
+  }
+
+  public Note getNoteAfterReloadFromRepo(String noteId) {
+    loadNoteFromRepo(noteId, new AuthenticationInfo(StringUtils.EMPTY));
+    return getNote(noteId);
   }
 
   public Folder getFolder(String folderId) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
@@ -1,0 +1,99 @@
+package org.apache.zeppelin.notebook.repo;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.PullCommand;
+import org.eclipse.jgit.api.PushCommand;
+import org.eclipse.jgit.api.RemoteAddCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+public class GitHubNotebookRepo extends GitNotebookRepo {
+  private static final Logger LOG = LoggerFactory.getLogger(GitNotebookRepo.class);
+  private ZeppelinConfiguration zeppelinConfiguration;
+  private Git git;
+
+  public GitHubNotebookRepo(ZeppelinConfiguration conf) throws IOException {
+    super(conf);
+
+    this.git = super.getGit();
+    this.zeppelinConfiguration = conf;
+
+    configureRemoteStream();
+    pullFromRemoteStream();
+  }
+
+  @Override
+  public Revision checkpoint(String pattern, String commitMessage, AuthenticationInfo subject) {
+    Revision revision = super.checkpoint(pattern, commitMessage, subject);
+
+    updateRemoteStream();
+
+    return revision;
+  }
+
+  private void configureRemoteStream() {
+    try {
+      LOG.debug("Setting up remote stream");
+      RemoteAddCommand remoteAddCommand = git.remoteAdd();
+      remoteAddCommand.setName(zeppelinConfiguration.getZeppelinNotebookGitRemoteOrigin());
+      remoteAddCommand.setUri(new URIish(zeppelinConfiguration.getZeppelinNotebookGitURL()));
+      remoteAddCommand.call();
+    } catch (GitAPIException e) {
+      e.printStackTrace();
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void updateRemoteStream() {
+    LOG.debug("Updating remote stream");
+
+    pullFromRemoteStream();
+    pushToRemoteSteam();
+  }
+
+  private void pullFromRemoteStream() {
+    try {
+      LOG.debug("Pull latest changed from remote stream");
+      PullCommand pullCommand = git.pull();
+      pullCommand.setCredentialsProvider(
+              new UsernamePasswordCredentialsProvider(
+                      zeppelinConfiguration.getZeppelinNotebookGitUsername(),
+                      zeppelinConfiguration.getZeppelinNotebookGitAccessToken()
+              )
+      );
+
+      pullCommand.call();
+
+    } catch (GitAPIException e) {
+      LOG.error("Error when pulling latest changes from remote repository");
+      e.printStackTrace();
+    }
+  }
+
+  private void pushToRemoteSteam() {
+    try {
+      LOG.debug("Push latest changed from remote stream");
+      PushCommand pushCommand = git.push();
+      pushCommand.setCredentialsProvider(
+              new UsernamePasswordCredentialsProvider(
+                      zeppelinConfiguration.getZeppelinNotebookGitUsername(),
+                      zeppelinConfiguration.getZeppelinNotebookGitAccessToken()
+              )
+      );
+
+      pushCommand.call();
+    } catch (GitAPIException e) {
+      LOG.error("Error when pushing latest changes from remote repository");
+      e.printStackTrace();
+    }
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.user.AuthenticationInfo;
-import org.eclipse.jgit.api.*;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
 import org.eclipse.jgit.diff.DiffEntry;
@@ -59,15 +59,13 @@ public class GitNotebookRepo extends VFSNotebookRepo {
 
   public GitNotebookRepo(ZeppelinConfiguration conf) throws IOException {
     super(conf);
-
     localPath = getRootDir().getName().getPath();
-    LOG.debug("Opening a git repo at '{}'", localPath);
+    LOG.info("Opening a git repo at '{}'", localPath);
     Repository localRepo = new FileRepository(Joiner.on(File.separator).join(localPath, ".git"));
     if (!localRepo.getDirectory().exists()) {
-      LOG.debug("Git repo {} does not exist, creating a new one", localRepo.getDirectory());
+      LOG.info("Git repo {} does not exist, creating a new one", localRepo.getDirectory());
       localRepo.create();
     }
-
     git = new Git(localRepo);
   }
 
@@ -111,7 +109,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
    */
   @Override
   public synchronized Note get(String noteId, String revId, AuthenticationInfo subject)
-      throws IOException {
+          throws IOException {
     Note note = null;
     RevCommit stash = null;
     try {
@@ -136,7 +134,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
         ObjectId dropped = git.stashDrop().setStashRef(0).call();
         Collection<RevCommit> stashes = git.stashList().call();
         LOG.debug("Stash applied as : {}, and dropped : {}, stash size: {}", applied, dropped,
-            stashes.size());
+                stashes.size());
       }
     } catch (GitAPIException e) {
       LOG.error("Failed to return note from revision \"{}\"", revId, e);
@@ -165,15 +163,14 @@ public class GitNotebookRepo extends VFSNotebookRepo {
 
   @Override
   public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
-      throws IOException {
-    LOG.debug("Setting log revision");
+          throws IOException {
     Note revisionNote = get(noteId, revId, subject);
     if (revisionNote != null) {
       save(revisionNote, subject);
     }
     return revisionNote;
   }
-  
+
   @Override
   public void close() {
     git.getRepository().close();
@@ -187,4 +184,5 @@ public class GitNotebookRepo extends VFSNotebookRepo {
   void setGit(Git git) {
     this.git = git;
   }
+
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -109,7 +109,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
    */
   @Override
   public synchronized Note get(String noteId, String revId, AuthenticationInfo subject)
-          throws IOException {
+      throws IOException {
     Note note = null;
     RevCommit stash = null;
     try {
@@ -134,7 +134,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
         ObjectId dropped = git.stashDrop().setStashRef(0).call();
         Collection<RevCommit> stashes = git.stashList().call();
         LOG.debug("Stash applied as : {}, and dropped : {}, stash size: {}", applied, dropped,
-                stashes.size());
+            stashes.size());
       }
     } catch (GitAPIException e) {
       LOG.error("Failed to return note from revision \"{}\"", revId, e);
@@ -163,14 +163,14 @@ public class GitNotebookRepo extends VFSNotebookRepo {
 
   @Override
   public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
-          throws IOException {
+      throws IOException {
     Note revisionNote = get(noteId, revId, subject);
     if (revisionNote != null) {
       save(revisionNote, subject);
     }
     return revisionNote;
   }
-
+  
   @Override
   public void close() {
     git.getRepository().close();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepoTest.java
@@ -1,0 +1,163 @@
+package org.apache.zeppelin.notebook.repo;
+
+
+import com.google.common.base.Joiner;
+import org.apache.commons.io.FileUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+
+import static org.mockito.Mockito.mock;
+
+public class GitHubNotebookRepoTest {
+  private static final Logger LOG = LoggerFactory.getLogger(GitNotebookRepoTest.class);
+
+  private static final String TEST_NOTE_ID = "2A94M5J1Z";
+
+  private File remoteZeppelinDir;
+  private File localZeppelinDir;
+  private String localNotebooksDir;
+  private String remoteNotebooksDir;
+  private ZeppelinConfiguration conf;
+  private GitHubNotebookRepo gitHubNotebookRepo;
+  private RevCommit firstCommitRevision;
+  private Git remoteGit;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = ZeppelinConfiguration.create();
+
+    String remoteRepositoryPath = System.getProperty("java.io.tmpdir") + "/ZeppelinTestRemote_";
+    String localRepositoryPath = System.getProperty("java.io.tmpdir") + "/ZeppelinTest_";
+
+    String currentPath = new File(".").getCanonicalFile().getPath();
+
+    remoteZeppelinDir = new File(remoteRepositoryPath);
+    remoteZeppelinDir.mkdirs();
+    new File(remoteZeppelinDir, "conf").mkdirs();
+
+    localZeppelinDir = new File(localRepositoryPath);
+    localZeppelinDir.mkdirs();
+    new File(localZeppelinDir, "conf").mkdirs();
+
+    localNotebooksDir = Joiner.on(File.separator).join(localRepositoryPath, "notebook");
+    remoteNotebooksDir = Joiner.on(File.separator).join(remoteRepositoryPath, "notebook");
+
+    File notebookDir = new File(localNotebooksDir);
+    notebookDir.mkdirs();
+
+    String remoteTestNoreDir = Joiner.on(File.separator).join(remoteNotebooksDir, TEST_NOTE_ID);
+    FileUtils.copyDirectory(
+            new File(
+                    Joiner.on(File.separator).join(
+                            currentPath,"zeppelin-server", "src", "test", "resources", TEST_NOTE_ID
+                    )
+            ), new File(remoteTestNoreDir)
+    );
+
+    Repository remoteRepository = new FileRepository(Joiner.on(File.separator).join(remoteNotebooksDir, ".git"));
+    remoteRepository.create(); // Create another repository
+
+    remoteGit = new Git(remoteRepository);
+    remoteGit.add().addFilepattern(".").call();
+    firstCommitRevision = remoteGit.commit().setMessage("First commit from remote repository").call();
+
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName(), remoteZeppelinDir.getAbsolutePath());
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(), notebookDir.getAbsolutePath());
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), "org.apache.zeppelin.notebook.repo.GitHubNotebookRepo");
+
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL.getVarName(), remoteNotebooksDir + File.separator + ".git");
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME.getVarName(), "token");
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN.getVarName(), "access-token");
+
+    gitHubNotebookRepo = new GitHubNotebookRepo(conf);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (!FileUtils.deleteQuietly(remoteZeppelinDir)) {
+      LOG.error("Failed to delete {} ", remoteZeppelinDir.getName());
+    }
+
+    if (!FileUtils.deleteQuietly(localZeppelinDir)) {
+      LOG.error("Failed to delete {} ", localZeppelinDir.getName());
+    }
+  }
+
+  @Test
+  public void pullChangesFromRemoteRepositoryOnLoadingNotebook() throws IOException, GitAPIException {
+    NotebookRepo.Revision firstHistoryRevision = gitHubNotebookRepo.revisionHistory(TEST_NOTE_ID, null).get(0);
+
+    assert(this.firstCommitRevision.getName().equals(firstHistoryRevision.id));
+  }
+
+  @Test
+  public void pullChangesFromRemoteRepositoryOnCheckpointing() throws GitAPIException, IOException {
+    // Create a new commit in the remote repository
+    RevCommit secondCommitRevision = remoteGit.commit().setMessage("Second commit from remote repository").call();
+
+    // Add a new paragraph to the local repository
+    Note note = gitHubNotebookRepo.get(TEST_NOTE_ID, null);
+    note.setInterpreterFactory(mock(InterpreterFactory.class));
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    paragraph.setText("%md text");
+    gitHubNotebookRepo.save(note, null);
+
+    // Commit and push the changes to remote repository
+    NotebookRepo.Revision thirdCommitRevision = gitHubNotebookRepo.checkpoint(
+            TEST_NOTE_ID, "Third commit from local repository", null);
+
+    // Check all the commits as seen from the local repository. The commits are ordered chronologically. The last
+    // commit is the first in the commit logs.
+    Iterator<RevCommit> revisions = gitHubNotebookRepo.getGit().log().all().call().iterator();
+
+    revisions.next(); // The Merge `master` commit after pushing to the remote repository
+
+    assert(thirdCommitRevision.id.equals(revisions.next().getName())); // The local commit after adding the paragraph
+
+    // The second commit done on the remote repository
+    assert(secondCommitRevision.getName().equals(revisions.next().getName()));
+
+    // The first commit done on the remote repository
+    assert(firstCommitRevision.getName().equals(revisions.next().getName()));
+  }
+
+  @Test
+  public void pushLocalChangesToRemoteRepositoryOnCheckpointing() throws IOException, GitAPIException {
+    // Add a new paragraph to the local repository
+    Note note = gitHubNotebookRepo.get(TEST_NOTE_ID, null);
+    note.setInterpreterFactory(mock(InterpreterFactory.class));
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    paragraph.setText("%md text");
+    gitHubNotebookRepo.save(note, null);
+
+    // Commit and push the changes to remote repository
+    NotebookRepo.Revision secondCommitRevision = gitHubNotebookRepo.checkpoint(
+            TEST_NOTE_ID, "Second commit from local repository", null);
+
+    // Check all the commits as seen from the local repository. The commits are ordered chronologically. The last
+    // commit is the first in the commit logs.
+    Iterator<RevCommit> revisions = remoteGit.log().all().call().iterator();
+
+    assert(secondCommitRevision.id.equals(revisions.next().getName())); // The local commit after adding the paragraph
+
+    // The first commit done on the remote repository
+    assert(firstCommitRevision.getName().equals(revisions.next().getName()));
+  }
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -60,6 +60,7 @@ public class GitNotebookRepoTest {
   @Before
   public void setUp() throws Exception {
     String zpath = System.getProperty("java.io.tmpdir") + "/ZeppelinTest_" + System.currentTimeMillis();
+    String currentPath = new File(".").getCanonicalFile().getPath();
     zeppelinDir = new File(zpath);
     zeppelinDir.mkdirs();
     new File(zeppelinDir, "conf").mkdirs();
@@ -70,9 +71,19 @@ public class GitNotebookRepoTest {
 
     String testNoteDir = Joiner.on(File.separator).join(notebooksDir, TEST_NOTE_ID);
     String testNoteDir2 = Joiner.on(File.separator).join(notebooksDir, TEST_NOTE_ID2);
-    FileUtils.copyDirectory(new File(Joiner.on(File.separator).join("src", "test", "resources", TEST_NOTE_ID)),
-        new File(testNoteDir));
-    FileUtils.copyDirectory(new File(Joiner.on(File.separator).join("src", "test", "resources", TEST_NOTE_ID2)),
+    FileUtils.copyDirectory(
+            new File(
+                    Joiner.on(File.separator).join(
+                            currentPath,"zeppelin-server", "src", "test", "resources", TEST_NOTE_ID
+                    )
+            ),
+            new File(testNoteDir));
+    FileUtils.copyDirectory(
+            new File(
+                    Joiner.on(File.separator).join(
+                            currentPath,"zeppelin-server", "src", "test", "resources", TEST_NOTE_ID2
+                    )
+            ),
         new File(testNoteDir2)
     );
 


### PR DESCRIPTION
### What is this PR for?
GitHub integration as a storage for notebooks.


### What type of PR is it?
Feature

### What is the Jira issue?
[ZEPPELIN-3092](https://issues.apache.org/jira/browse/ZEPPELIN-3092)

### How should this be tested?
1. Change the configuration in `zeppelin-site.xml` to enable GitHub integration (add GitHub url, username, access token and origin) as described in https://github.com/apache/zeppelin/compare/master...mohamagdy:zeppelin-3092-remote-github-integration?expand=1#diff-89104d48f0358450399a6f679bba9c4f
2. Start the Zeppelin server
3. Open an existing notebook or create a new notebook
4. Do some changes to the notebook, for example add a new paragraph
5. Click on the versioning button on the top menu to commit and save changes
6. Checkout the changes in the GitHub repository. The changes should be reflected 

### Questions:
* **Does the licenses files need update?**
No

* **Is there breaking changes for older versions?**
No

* **Does this needs documentation?**
Yes. Documentation is updated as part of the pull request.
